### PR TITLE
fix: Enhance error handling for invalid credentials in API client

### DIFF
--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -146,6 +146,16 @@ apiClient.interceptors.response.use(
       // Get the request URL path
       const requestUrl = error.config?.url || "";
       const status = error.response?.status;
+      const message = error.response?.data?.message || error.message || "An error occurred";
+      debugger;
+      if (message === "Invalid credentials") {
+        return Promise.reject({
+          data: null,
+          message: "Invalid credentials",
+          success: false,
+          status: 401,
+        });
+      }
 
       // Handle authentication errors (401 Unauthorized, 403 Forbidden)
       if (status === 401) {


### PR DESCRIPTION
This commit adds specific handling for the "Invalid credentials" error message in the API client. When this error occurs, a structured rejection is returned with a 401 status, improving the clarity of authentication error responses.